### PR TITLE
Global trivial dtor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "peeking_take_while"
@@ -678,6 +678,7 @@ name = "vulkan-layer-macros"
 version = "0.1.0"
 dependencies = [
  "ash",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.27",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,6 +662,7 @@ version = "0.1.0"
 dependencies = [
  "ash",
  "bytemuck",
+ "cfg-if",
  "log",
  "mockall",
  "num-traits",

--- a/vulkan-layer-macros/Cargo.toml
+++ b/vulkan-layer-macros/Cargo.toml
@@ -13,4 +13,5 @@ syn = { version = "2.0.18", features = ["full"] }
 
 [dev-dependencies]
 ash = "0.37.2"
+once_cell = "1.18.0"
 vulkan-layer = { path = "../vulkan-layer" }

--- a/vulkan-layer-macros/src/lib.rs
+++ b/vulkan-layer-macros/src/lib.rs
@@ -101,6 +101,7 @@ pub fn auto_deviceinfo_impl(_: TokenStream, item: TokenStream) -> TokenStream {
 /// ```
 /// # use std::sync::Arc;
 /// # use vulkan_layer::{InstanceHooks, DeviceHooks, auto_instanceinfo_impl, auto_deviceinfo_impl, declare_introspection_queries, auto_globalhooksinfo_impl, GlobalHooks, Layer, LayerManifest, Global};
+/// # use once_cell::sync::Lazy;
 /// # use ash::{vk, self};
 /// #
 /// struct InstanceInfo;
@@ -127,6 +128,11 @@ pub fn auto_deviceinfo_impl(_: TokenStream, item: TokenStream) -> TokenStream {
 /// #     type InstanceInfoContainer = InstanceInfo;
 /// #     type DeviceInfoContainer = DeviceInfo;
 /// #     
+/// #     fn global_instance() -> &'static Global<Self> {
+/// #         static GLOBAL: Lazy<Global<MyLayer>> = Lazy::new(Default::default);
+/// #         &*GLOBAL
+/// #     }
+/// #
 /// #     fn manifest() -> LayerManifest {
 /// #         Default::default()
 /// #     }

--- a/vulkan-layer/Cargo.toml
+++ b/vulkan-layer/Cargo.toml
@@ -13,6 +13,7 @@ thiserror = "1.0.40"
 vulkan-layer-macros = { path = "../vulkan-layer-macros" }
 mockall = { version = "0.11.4", optional = true }
 bytemuck = "1.13.1"
+cfg-if = "1.0.0"
 
 [features]
 default = []

--- a/vulkan-layer/src/global_simple_intercept.rs
+++ b/vulkan-layer/src/global_simple_intercept.rs
@@ -27,7 +27,9 @@ use thiserror::Error;
 pub mod generated;
 pub use generated::*;
 
-use crate::{DeviceHooks, InstanceHooks, LayerResult, LayerVulkanCommand, VkLayerInstanceLink};
+use crate::{
+    DeviceHooks, Global, InstanceHooks, LayerResult, LayerVulkanCommand, VkLayerInstanceLink,
+};
 
 #[derive(Error, Debug)]
 pub enum TryFromExtensionError {
@@ -195,6 +197,8 @@ pub trait Layer: Sync + Default + 'static {
     type DeviceInfoContainer: Borrow<Self::DeviceInfo> + Sync + Send;
 
     fn manifest() -> LayerManifest;
+
+    fn global_instance() -> &'static Global<Self>;
 
     fn get_global_hooks_info(&self) -> &Self::GlobalHooksInfo;
 

--- a/vulkan-layer/src/lazy_collection.rs
+++ b/vulkan-layer/src/lazy_collection.rs
@@ -1,0 +1,251 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    borrow::Cow,
+    cell::RefCell,
+    collections::BTreeMap,
+    fmt::{self, Display, Formatter},
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+};
+
+use once_cell::unsync::OnceCell;
+
+/// The [CheckEmpty] trait allows to check if a collection is empty.
+pub trait CheckEmpty: Default + Clone {
+    /// Returns `true` if the collection contains no elements.
+    fn is_empty(&self) -> bool;
+}
+
+impl<T: Clone> CheckEmpty for Vec<T> {
+    fn is_empty(&self) -> bool {
+        Vec::<T>::is_empty(self)
+    }
+}
+
+impl<K: Clone, V: Clone> CheckEmpty for BTreeMap<K, V> {
+    fn is_empty(&self) -> bool {
+        BTreeMap::<K, V>::is_empty(self)
+    }
+}
+
+/// A collection wrapper, that guarantees that an empty collection can be trivially destructed.
+///
+/// This makes it easy to use collections in a global object that requires trivially destructible.
+/// When using global objects in a dynamic link library that allow a process to load and unload the
+/// dynamic link library multiple times, no OS provides reliable way to teardown the global
+/// resources allocated, so all global resources used should be trivially destructible.
+///
+/// This is especially true for an Android Vulkan layer. When querying the capabilities of Vulkan
+/// layers, the Android Vulkan loader will load the shared object and call into the exposed
+/// introspection queries, and unload the shared object once the task is done. The Android Vulkan
+/// loader may load the shared object later again if the layer is activated. However, on Android
+/// there is no reliable way to register a callback when the shared object is actually unloaded.
+///
+/// Similar to [RefCell], even if `T` implements [Sync], [`LazyCollection<T>`] is not [Sync],
+/// because a single-threaded way is used to test if the underlying collection is empty and destroy
+/// the allocation
+#[derive(Default)]
+pub struct LazyCollection<T: CheckEmpty> {
+    inner: OnceCell<T>,
+    // Mark this type !Sync even if T implements Sync.
+    marker: PhantomData<RefCell<T>>,
+}
+
+impl<T: CheckEmpty> LazyCollection<T> {
+    /// Creates a new `LazyCollection` containing `value`.
+    ///
+    /// # Examples
+    /// ```
+    /// # use vulkan_layer::lazy_collection::LazyCollection;
+    /// let c = LazyCollection::new(vec![42]);
+    /// ```
+    pub fn new(value: T) -> Self {
+        Self {
+            inner: OnceCell::with_value(value),
+            ..Default::default()
+        }
+    }
+
+    /// Gets the reference to the underlying collection. Returns an owned empty T if the underlying
+    /// collection is empty.
+    ///
+    /// # Examples
+    /// ```
+    /// # use vulkan_layer::lazy_collection::LazyCollection;
+    /// let vec = LazyCollection::new(vec![42]);
+    /// let vec1 = vec.get();
+    /// assert_eq!(*vec1, vec![42]);
+    /// let vec2 = vec.get();
+    /// // vec1 and vec2 point to the same location.
+    /// assert!(std::ptr::eq(&*vec1, &*vec2));
+    /// ```
+    pub fn get(&self) -> Cow<T> {
+        // The destructor for None is a no-op, while this is not guaranteed for an empty T.
+        // Therefore, we can't use &T as the return type and return a reference to a static empty T
+        // when the underlying collection is empty.
+        match self.inner.get() {
+            Some(collection) => Cow::Borrowed(collection),
+            None => Cow::Owned(Default::default()),
+        }
+    }
+
+    /// Gets a mutable reference to the underlying collection, create an empty collection if the
+    /// underlying collection was empty.
+    ///
+    /// # Examples
+    /// ```
+    /// # use vulkan_layer::lazy_collection::LazyCollection;
+    /// let mut vec = LazyCollection::<Vec<u32>>::default();
+    /// let mut mut_vec = vec.get_mut_or_default();
+    /// mut_vec.push(42);
+    /// assert_eq!(*mut_vec, vec![42]);
+    /// drop(mut_vec);
+    ///
+    /// let mut mut_vec = vec.get_mut_or_default();
+    /// mut_vec.remove(0);
+    /// assert_eq!(*mut_vec, vec![]);
+    /// drop(mut_vec);
+    /// // This won't cause a memory leak.
+    /// std::mem::forget(vec);
+    /// ```
+    pub fn get_mut_or_default(&mut self) -> CollectionRefMut<'_, T> {
+        // Ensure that inner is initialized.
+        self.inner.get_or_init(Default::default);
+        CollectionRefMut(&mut self.inner)
+    }
+}
+
+/// A wrapper type for a mutably borrowed value from a [LazyCollection].
+#[derive(Debug)]
+pub struct CollectionRefMut<'a, T: CheckEmpty>(&'a mut OnceCell<T>);
+
+impl<'a, T: CheckEmpty> Drop for CollectionRefMut<'a, T> {
+    fn drop(&mut self) {
+        let should_destroy = self
+            .0
+            .get()
+            .map(|collection| collection.is_empty())
+            .unwrap_or(true);
+        if !should_destroy {
+            return;
+        }
+        self.0.take();
+    }
+}
+
+impl<T: CheckEmpty> Deref for CollectionRefMut<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        // CollectionRefMut will always be initialized. get_mut_or_default is the only place we
+        // initialize CollectionRefMut, and we never mutate it.
+        self.0.get().unwrap()
+    }
+}
+
+impl<T: CheckEmpty> DerefMut for CollectionRefMut<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // CollectionRefMut will always be initialized. get_mut_or_default is the only place we
+        // initialize CollectionRefMut, and we never mutate it.
+        self.0.get_mut().unwrap()
+    }
+}
+
+impl<T: CheckEmpty + Display> Display for CollectionRefMut<'_, T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        (**self).fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_empty_get_shouldnt_leak() {
+        // We rely on the Miri test to detect the resource leak.
+        let lazy_vec = LazyCollection::<Vec<u32>>::new(vec![]);
+        let empty_vec = lazy_vec.get();
+        assert!(empty_vec.is_empty());
+        std::mem::forget(lazy_vec);
+    }
+
+    #[test]
+    fn test_non_empty_get_should_point_to_the_same_location() {
+        let lazy_vec = LazyCollection::new(vec![42]);
+        let vec1 = lazy_vec.get();
+        assert_eq!(*vec1, vec![42]);
+        let vec2 = lazy_vec.get();
+        std::ptr::eq(&*vec1, &*vec2);
+    }
+
+    #[test]
+    fn test_get_mut_should_get_the_content() {
+        let mut lazy_vec = LazyCollection::new(vec![64]);
+        {
+            let mut vec = lazy_vec.get_mut_or_default();
+            assert_eq!(*vec, vec![64]);
+            vec.push(33);
+            assert_eq!(*vec, vec![64, 33]);
+        }
+        let vec = lazy_vec.get_mut_or_default();
+        assert_eq!(*vec, vec![64, 33]);
+    }
+
+    #[test]
+    fn test_get_mut_empty_should_return_an_empty_collection() {
+        let mut lazy_vec = LazyCollection::<Vec<u32>>::default();
+        assert!(lazy_vec.get_mut_or_default().is_empty());
+    }
+
+    #[test]
+    fn test_get_mut_empty_shouldnt_leak() {
+        // We rely on the Miri test to detect the resource leak.
+        let mut lazy_vec = LazyCollection::<Vec<u32>>::default();
+        {
+            let vec = lazy_vec.get_mut_or_default();
+            assert!(vec.is_empty());
+        }
+        std::mem::forget(lazy_vec);
+    }
+
+    #[test]
+    fn test_get_mut_insert_and_clear_shouldnt_leak() {
+        // We rely on the Miri test to detect the resource leak.
+        // 2 test cases. One on the same CollectionRefMut. One on 2 different CollectionRefMut's.
+        {
+            let mut lazy_vec = LazyCollection::<Vec<u32>>::default();
+            let mut vec = lazy_vec.get_mut_or_default();
+            vec.push(42);
+            assert!(!vec.is_empty());
+            vec.remove(0);
+            assert!(vec.is_empty());
+            drop(vec);
+            std::mem::forget(lazy_vec);
+        }
+        {
+            let mut lazy_vec = LazyCollection::<Vec<u32>>::default();
+            let mut vec = lazy_vec.get_mut_or_default();
+            vec.push(42);
+            assert!(!vec.is_empty());
+            drop(vec);
+            let mut vec = lazy_vec.get_mut_or_default();
+            vec.remove(0);
+            assert!(vec.is_empty());
+            drop(vec);
+            std::mem::forget(lazy_vec);
+        }
+    }
+}

--- a/vulkan-layer/tests/utils/mod.rs
+++ b/vulkan-layer/tests/utils/mod.rs
@@ -28,7 +28,7 @@ use std::{
 use vulkan_layer::{
     fill_vk_out_array,
     test_utils::{
-        ArcDel, Del, TestLayerWrapper, VkLayerDeviceCreateInfo, VkLayerDeviceLink, VkLayerFunction,
+        ArcDel, Del, VkLayerDeviceCreateInfo, VkLayerDeviceLink, VkLayerFunction,
         VkLayerInstanceCreateInfo,
     },
     ApiVersion, Extension, ExtensionProperties, Feature, Global, IsCommandEnabled, Layer,
@@ -809,8 +809,6 @@ unsafe extern "system" fn get_instance_proc_addr(
         }
     }
 }
-
-pub type MockLayer = TestLayerWrapper;
 
 pub fn create_entry<T: Layer>() -> ash::Entry {
     unsafe {


### PR DESCRIPTION
* Make Global trivially destructible if no instances are alive.
* Ask the user to provide the static storage of the Global object, so that we can remove the complicated instance per type logic in Global.